### PR TITLE
(feat) fixes #2557: makes ETH routes non Balancer specific

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ if (result.error) {
 const env = process.env.NODE_ENV
 const port = process.env.PORT
 const certPassphrase = process.env.CERT_PASSPHRASE
-const balancerNetwork = process.env.BALANCER_NETWORK
+const ethereumChain = process.env.BALANCER_NETWORK
 let certPath = process.env.CERT_PATH
 
 if ((typeof certPath === 'undefined' && certPath == null) || certPath === '') {
@@ -79,4 +79,4 @@ server.listen(port)
 server.on('error', onError)
 server.on('listening', onListening)
 
-console.log('server: gateway-api | port:', port, '| balancer-network:', balancerNetwork);
+console.log('server: gateway-api | port:', port, '| ethereum-chain:', ethereumChain);

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ if (result.error) {
 const env = process.env.NODE_ENV
 const port = process.env.PORT
 const certPassphrase = process.env.CERT_PASSPHRASE
-const ethereumChain = process.env.BALANCER_NETWORK
+const ethereumChain = process.env.ETHEREUM_CHAIN
 let certPath = process.env.CERT_PATH
 
 if ((typeof certPath === 'undefined' && certPath == null) || certPath === '') {

--- a/src/routes/balancer.route.js
+++ b/src/routes/balancer.route.js
@@ -16,7 +16,6 @@ const eth = new Ethereum(process.env.BALANCER_NETWORK)
 const denomMultiplier = 1e18
 const swapMoreThanMaxPriceError = 'Swap price exceeds maxPrice'
 const swapLessThanMaxPriceError = 'Swap price lower than maxPrice'
-const separator = ','
 
 router.use((req, res, next) => {
   const cert = req.connection.getPeerCertificate()
@@ -187,7 +186,7 @@ router.post('/sell', async (req, res) => {
       amount,
     )
 
-    const price = expectedOut / amount 
+    const price = expectedOut / amount
     debug(`Price: ${price.toString()}`)
     if (!maxPrice || price >= maxPrice) {
       // pass swaps to exchange-proxy to complete trade
@@ -304,119 +303,6 @@ router.post('/buy', async (req, res) => {
       })
       debug(`Swap price ${price} exceeds maxPrice ${maxPrice}`)
     }
-  } catch (err) {
-    let reason
-    err.reason ? reason = err.reason : reason = statusMessages.operation_error
-    res.status(500).json({
-      error: reason,
-      message: err
-    })
-  }
-})
-
-router.post('/allowances', async (req, res) => {
-  /*
-      POST: /allowances
-      x-www-form-urlencoded: {
-        privateKey:{{privateKey}}
-        tokenAddressList:{{tokenAddressList}}
-      }
-  */
-  const initTime = Date.now()
-  const paramData = getParamData(req.body)
-  const privateKey = paramData.privateKey
-  let wallet
-  try {
-    wallet = new ethers.Wallet(privateKey, eth.provider)
-  } catch (err) {
-    let reason
-    err.reason ? reason = err.reason : reason = 'Error getting wallet'
-    res.status(500).json({
-      error: reason,
-      message: err
-    })
-    return
-  }
-  let tokenAddressList
-  if (paramData.tokenAddressList) {
-    tokenAddressList = paramData.tokenAddressList.split(separator)
-  }
-  debug(tokenAddressList)
-  const spender = balancer.exchangeProxy
-
-  const approvals = {}
-  try {
-    Promise.all(
-      tokenAddressList.map(async (key) =>
-      approvals[key] = await eth.getERC20Allowance(wallet, spender, key)
-      )).then(() => {
-      res.status(200).json({
-        network: eth.network,
-        timestamp: initTime,
-        latency: latency(initTime, Date.now()),
-        spender: spender,
-        approvals: approvals,
-      })
-    }
-    )
-  } catch (err) {
-    let reason
-    err.reason ? reason = err.reason : reason = statusMessages.operation_error
-    res.status(500).json({
-      error: reason,
-      message: err
-    })
-  }
-})
-
-router.post('/approve', async (req, res) => {
-  /*
-      POST: /approve
-      x-www-form-urlencoded: {
-        privateKey:{{privateKey}}
-        tokenAddress:"0x....."
-        amount:{{amount}}
-      }
-  */
-  const initTime = Date.now()
-  const paramData = getParamData(req.body)
-  const privateKey = paramData.privateKey
-  let wallet
-  try {
-    wallet = new ethers.Wallet(privateKey, eth.provider)
-  } catch (err) {
-    let reason
-    err.reason ? reason = err.reason : reason = 'Error getting wallet'
-    res.status(500).json({
-      error: reason,
-      message: err
-    })
-    return
-  }
-  const tokenAddress = paramData.tokenAddress
-  const spender = balancer.exchangeProxy
-  let amount
-  paramData.amount  ? amount = ethers.utils.parseEther(paramData.amount)
-                    : amount = ethers.utils.parseEther('1000000000') // approve for 1 billion units if no amount specified
-  let gasPrice
-  if (paramData.gasPrice) {
-    gasPrice = parseFloat(paramData.gasPrice)
-  }
-
-  try {
-    // call approve function
-    const approval = await eth.approveERC20(wallet, spender, tokenAddress, amount, gasPrice)
-
-    // submit response
-    res.status(200).json({
-      network: eth.network,
-      timestamp: initTime,
-      latency: latency(initTime, Date.now()),
-      tokenAddress: tokenAddress,
-      spender: spender,
-      amount: amount / 1e18.toString(),
-      approval: approval
-    })
   } catch (err) {
     let reason
     err.reason ? reason = err.reason : reason = statusMessages.operation_error

--- a/src/routes/eth.route.js
+++ b/src/routes/eth.route.js
@@ -71,7 +71,7 @@ router.post('/allowances', async (req, res) => {
       x-www-form-urlencoded: {
         privateKey:{{privateKey}}
         tokenAddressList:{{tokenAddressList}}
-        spenderAddress:"0x....."
+        connector:{{connector_name}}"
       }
   */
   const initTime = Date.now()
@@ -126,7 +126,7 @@ router.post('/approve', async (req, res) => {
       x-www-form-urlencoded: {
         privateKey:{{privateKey}}
         tokenAddress:"0x....."
-        spenderAddress:"0x....."
+        connector:{{connector_name}}"
         amount:{{amount}}
       }
   */

--- a/src/routes/eth.route.js
+++ b/src/routes/eth.route.js
@@ -71,7 +71,7 @@ router.post('/allowances', async (req, res) => {
       x-www-form-urlencoded: {
         privateKey:{{privateKey}}
         tokenAddressList:{{tokenAddressList}}
-        connector:{{connector_name}}"
+        connector:{{connector_name}}
       }
   */
   const initTime = Date.now()
@@ -126,7 +126,8 @@ router.post('/approve', async (req, res) => {
       x-www-form-urlencoded: {
         privateKey:{{privateKey}}
         tokenAddress:"0x....."
-        connector:{{connector_name}}"
+        decimals: {{token_decimals}}
+        connector:{{connector_name}}
         amount:{{amount}}
       }
   */


### PR DESCRIPTION
Fixes https://github.com/CoinAlpha/hummingbot/issues/2557

To make these functions non Balancer specific, this PR adds a `spenderAddress` parameter to `/eth/approve` and `/eth/allowances`, so the Balancer connector in the client needs to be changed to pass in the Balancer exchangeProxy address (mainnet: `0x3E66B66Fd1d0b02fDa6C811Da9E0547970DB2f21`). 

I think the Balancer exchangeProxy address should be a global parameter that we set to the current mainnet address. If users want to test on Kovan, they are responsible for changing it.

