### PR TITLE
(feat) poll for eth tx

### DIFF
--- a/src/routes/balancer.route.js
+++ b/src/routes/balancer.route.js
@@ -197,7 +197,7 @@ router.post('/sell', async (req, res) => {
     debug(`Price: ${price.toString()}`)
     if (!maxPrice || price >= maxPrice) {
       // pass swaps to exchange-proxy to complete trade
-      const txObj = await balancer.swapExactIn(
+      const tx = await balancer.swapExactIn(
         wallet,
         swaps,
         baseTokenAddress,   // tokenIn is base asset
@@ -217,9 +217,7 @@ router.post('/sell', async (req, res) => {
         amount: parseFloat(paramData.amount),
         expectedOut: expectedOut / denomMultiplier,
         price: price,
-        gasUsed: parseInt(txObj.gasUsed),
-        txHash: txObj.transactionHash,
-        status: txObj.status,
+        txHash: tx.hash,
       })
     } else {
       res.status(200).json({
@@ -286,7 +284,7 @@ router.post('/buy', async (req, res) => {
     debug(`Price: ${price.toString()}`)
     if (!maxPrice || price <= maxPrice) {
       // pass swaps to exchange-proxy to complete trade
-      const txObj = await balancer.swapExactOut(
+      const tx = await balancer.swapExactOut(
         wallet,
         swaps,
         quoteTokenAddress,   // tokenIn is quote asset
@@ -305,9 +303,7 @@ router.post('/buy', async (req, res) => {
         amount: parseFloat(paramData.amount),
         expectedIn: expectedIn / denomMultiplier,
         price: price,
-        gasUsed: parseInt(txObj.gasUsed),
-        txHash: txObj.transactionHash,
-        status: txObj.status,
+        txHash: tx.hash,
       })
     } else {
       res.status(200).json({

--- a/src/routes/uniswap.route.js
+++ b/src/routes/uniswap.route.js
@@ -184,7 +184,7 @@ router.post('/sell', async (req, res) => {
     debug(`Price: ${price.toString()}`)
     if (!maxPrice || price >= maxPrice) {
       // pass swaps to exchange-proxy to complete trade
-      const txObj = await uniswap.swapExactIn(
+      const tx = await uniswap.swapExactIn(
         wallet,
         trade,
         baseTokenAddress,
@@ -201,9 +201,7 @@ router.post('/sell', async (req, res) => {
         amount: amount,
         expectedOut: expectedOut.toSignificant(8),
         price: price,
-        gasUsed: parseInt(txObj.gasUsed),
-        txHash: txObj.transactionHash,
-        status: txObj.status,
+        txHash: tx.hash,
       })
     } else {
       res.status(200).json({
@@ -264,7 +262,7 @@ router.post('/buy', async (req, res) => {
     debug(`Price: ${price.toString()}`)
     if (!maxPrice || price <= maxPrice) {
       // pass swaps to exchange-proxy to complete trade
-      const txObj = await uniswap.swapExactOut(
+      const tx = await uniswap.swapExactOut(
         wallet,
         trade,
         baseTokenAddress,
@@ -281,9 +279,7 @@ router.post('/buy', async (req, res) => {
         amount: amount,
         expectedIn: expectedIn.toSignificant(8),
         price: price,
-        gasUsed: parseInt(txObj.gasUsed),
-        txHash: txObj.transactionHash,
-        status: txObj.status,
+        txHash: tx.hash,
       })
     } else {
       res.status(200).json({

--- a/src/services/balancer.js
+++ b/src/services/balancer.js
@@ -143,8 +143,7 @@ export default class Balancer {
       }
     )
     debug(`Tx Hash: ${tx.hash}`);
-    const txObj = await tx.wait()
-    return txObj
+    return tx
   }
 
   async swapExactOut (wallet, swaps, tokenIn, tokenOut, expectedIn, gasPrice) {
@@ -161,7 +160,6 @@ export default class Balancer {
       }
     )
     debug(`Tx Hash: ${tx.hash}`)
-    const txObj = await tx.wait()
-    return txObj
+    return tx
   }
 }

--- a/src/services/uniswap.js
+++ b/src/services/uniswap.js
@@ -85,8 +85,7 @@ export default class Uniswap {
     )
 
     debug(`Tx Hash: ${tx.hash}`);
-    const txObj = await tx.wait()
-    return txObj
+    return tx
   }
 
   async swapExactOut (wallet, trade, tokenAddress, gasPrice) {
@@ -110,7 +109,6 @@ export default class Uniswap {
     )
 
     debug(`Tx Hash: ${tx.hash}`);
-    const txObj = await tx.wait()
-    return txObj
+    return tx
   }
 }


### PR DESCRIPTION
This PR changes changes the `buy` and `sell` functions for Uniswap and Balancer so that they only return the transaction hash `txHash`. Afterwards, the client poll for status by passing `txHash` as param in a POST request to `/eth/get-receipt`, which returns the transaction status.

If transaction has not been confirmed, output is:
```
confirmed: false,
receipt: {}
```

If transaction has been confirmed, output is:
```
confirmed: true,
receipt: {
  gasUsed: int,
  blockNumber: int,
  confirmations: int,
  status: 1, // 0 = fail, 1 = success
}
```