### PR TITLE
Feat/new eth routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ PORT=5000
 # ipv6 format for locahost ["::ffff:127.0.0.1", "::ffff:1", "fe80::1", "::1"]
 IP_WHITELIST=
 
-HUMMINGBOT_CLIENT_ID={client_id}
+HUMMINGBOT_INSTANCE_ID={client_id}
 
 # Celo
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@uniswap/sdk": "^3.0.3",
     "@balancer-labs/sor": "^0.3.3",
     "@terra-money/terra.js": "^0.5.8",
+    "@uniswap/sdk": "^3.0.3",
+    "app-root-path": "^3.0.0",
     "bignumber.js": "^9.0.0",
     "body-parser": "^1.19.0",
     "capture-console": "^1.0.1",
@@ -26,7 +27,8 @@
     "helmet": "^4.1.1",
     "http-status-codes": "^2.1.3",
     "lodash": "^4.17.20",
-    "util": "^0.12.3"
+    "util": "^0.12.3",
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/src/app.js
+++ b/src/app.js
@@ -5,6 +5,7 @@ import helmet from 'helmet'
 import { statusMessages } from './services/utils';
 import { validateAccess } from './services/access';
 import { IpFilter } from 'express-ipfilter'
+import { logger } from './services/logger';
 
 // Routes
 import apiRoutes from './routes/index.route'
@@ -17,7 +18,7 @@ import uniswapRoutes from './routes/uniswap.route'
 // terminate if environment not found
 const result = dotenv.config();
 if (result.error) {
-  console.log(result.error);
+  logger.error(result.error);
   process.exit(1);
 }
 
@@ -39,12 +40,12 @@ app.use(bodyParser.urlencoded({ extended: true }));
 app.use(validateAccess)
 
 // mount all routes to this path
-app.use('/uniswap', validateAccess, uniswapRoutes);
-app.use('/api', validateAccess, apiRoutes);
-app.use('/eth', validateAccess, ethRoutes);
-// app.use('/celo', validateAccess, celoRoutes);
-app.use('/terra', validateAccess, terraRoutes);
-app.use('/balancer', validateAccess, balancerRoutes);
+app.use('/uniswap', uniswapRoutes);
+app.use('/api', apiRoutes);
+app.use('/eth', ethRoutes);
+// app.use('/celo', celoRoutes);
+app.use('/terra', terraRoutes);
+app.use('/balancer', balancerRoutes);
 
 app.get('/', (req, res, next) => {
   res.send('ok')
@@ -54,18 +55,12 @@ app.get('/', (req, res, next) => {
  * Catch all 404 response when routes are not found
  */
 app.use((req, res, next) => {
+  const message = `${statusMessages.page_not_found} at ${req.originalUrl}`
+  logger.error(message)
   res.status(404).send({
     error: 'Page not found',
+    message: message
   });
 });
-
-// // strip stacktrace on error
-// app.use((err, req, res, next) => {
-//   // console.log('Error handler', err)
-//   res.status(err.status || 500)
-//   res.json({
-//     error: err.message,
-//   })
-// })
 
 export default app;

--- a/src/index.js
+++ b/src/index.js
@@ -8,11 +8,12 @@ import fs from 'fs'
 
 // relative imports
 import app from './app'
+import { logger } from './services/logger'
 
 // terminate if environment not found
 const result = dotenv.config();
 if (result.error) {
-  console.log(result.error);
+  logger.info(result.error);
   process.exit(1);
 }
 
@@ -80,6 +81,12 @@ server.listen(port)
 server.on('error', onError)
 server.on('listening', onListening)
 
-console.log('server: gateway-api | port:', port)
-console.log(' - ethereum-chain:', ethereumChain)
-console.log(' - terra-chain:', terraChain)
+const serverConfig = {
+  app: 'gateway-api',
+  port: port,
+  ethereumChain: ethereumChain,
+  terraChain: terraChain
+}
+
+logger.info(JSON.stringify(serverConfig))
+console.log(serverConfig)

--- a/src/routes/balancer.route.js
+++ b/src/routes/balancer.route.js
@@ -84,9 +84,8 @@ router.post('/sell-price', async (req, res) => {
       maxSwaps,
     )
 
-    const gasLimit = estimateGasLimit(swaps.length)
-
     if (swaps != null && expectedOut != null) {
+      const gasLimit = estimateGasLimit(swaps.length)
       res.status(200).json({
         network: balancer.network,
         timestamp: initTime,
@@ -145,9 +144,8 @@ router.post('/buy-price', async (req, res) => {
       maxSwaps,
     )
 
-    const gasLimit = estimateGasLimit(swaps.length)
-
     if (swaps != null && expectedIn != null) {
+      const gasLimit = estimateGasLimit(swaps.length)
       res.status(200).json({
         network: balancer.network,
         timestamp: initTime,

--- a/src/routes/eth.route.js
+++ b/src/routes/eth.route.js
@@ -3,6 +3,7 @@ import express from 'express';
 
 import { getParamData, latency, reportConnectionError, statusMessages } from '../services/utils';
 import Ethereum from '../services/eth';
+import { logger } from '../services/logger';
 
 const router = express.Router()
 const eth = new Ethereum(process.env.ETHEREUM_CHAIN)
@@ -28,6 +29,7 @@ router.post('/balances', async (req, res) => {
   try {
     wallet = new ethers.Wallet(privateKey, eth.provider)
   } catch (err) {
+    logger.error(req.originalUrl, { message: err })
     let reason
     err.reason ? reason = err.reason : reason = 'Error getting wallet'
     res.status(500).json({
@@ -57,6 +59,7 @@ router.post('/balances', async (req, res) => {
       })
     })
   } catch (err) {
+    logger.error(req.originalUrl, { message: err })
     let reason
     err.reason ? reason = err.reason : reason = statusMessages.operation_error
     res.status(500).json({
@@ -83,6 +86,7 @@ router.post('/allowances', async (req, res) => {
   try {
     wallet = new ethers.Wallet(privateKey, eth.provider)
   } catch (err) {
+    logger.error(req.originalUrl, { message: err })
     let reason
     err.reason ? reason = err.reason : reason = 'Error getting wallet'
     res.status(500).json({
@@ -112,6 +116,7 @@ router.post('/allowances', async (req, res) => {
     }
     )
   } catch (err) {
+    logger.error(req.originalUrl, { message: err })
     let reason
     err.reason ? reason = err.reason : reason = statusMessages.operation_error
     res.status(500).json({
@@ -140,6 +145,7 @@ router.post('/approve', async (req, res) => {
   try {
     wallet = new ethers.Wallet(privateKey, eth.provider)
   } catch (err) {
+    logger.error(req.originalUrl, { message: err })
     let reason
     err.reason ? reason = err.reason : reason = 'Error getting wallet'
     res.status(500).json({
@@ -174,6 +180,7 @@ router.post('/approve', async (req, res) => {
       approval: approval
     })
   } catch (err) {
+    logger.error(req.originalUrl, { message: err })
     let reason
     err.reason ? reason = err.reason : reason = statusMessages.operation_error
     res.status(500).json({
@@ -200,6 +207,7 @@ router.post('/get-weth', async (req, res) => {
   try {
     wallet = new ethers.Wallet(privateKey, eth.provider)
   } catch (err) {
+    logger.error(req.originalUrl, { message: err })
     let reason
     err.reason ? reason = err.reason : reason = 'Error getting wallet'
     res.status(500).json({
@@ -227,6 +235,7 @@ router.post('/get-weth', async (req, res) => {
       result: response
     })
   } catch (err) {
+    logger.error(req.originalUrl, { message: err })
     let reason
     err.reason ? reason = err.reason : reason = statusMessages.operation_error
     res.status(500).json({

--- a/src/routes/eth.route.js
+++ b/src/routes/eth.route.js
@@ -126,6 +126,123 @@ router.post('/allowances', async (req, res) => {
   }
 })
 
+router.post('/balances-2', async (req, res) => {
+  /*
+      POST: /balances
+      x-www-form-urlencoded: {
+        privateKey:{{privateKey}}
+        tokenAddressList:{{tokenAddressList}}
+        tokenDecimalList:{{tokenDecimalList}}
+      }
+  */
+  const initTime = Date.now()
+  const paramData = getParamData(req.body)
+  const privateKey = paramData.privateKey
+  let wallet
+  try {
+    wallet = new ethers.Wallet(privateKey, eth.provider)
+  } catch (err) {
+    let reason
+    err.reason ? reason = err.reason : reason = 'Error getting wallet'
+    res.status(500).json({
+      error: reason,
+      message: err
+    })
+    return
+  }
+  let tokenAddressList
+  if (paramData.tokenAddressList) {
+    tokenAddressList = paramData.tokenAddressList.split(',')
+  }
+  let tokenDecimalList
+  if (paramData.tokenDecimalList) {
+    tokenDecimalList = paramData.tokenDecimalList.split(',')
+  }
+
+  const balances = {}
+  balances.ETH = await eth.getETHBalance(wallet, privateKey)
+  try {
+    Promise.all(
+      tokenAddressList.map(async (value, index) =>
+      balances[value] = await eth.getERC20Balance(wallet, value, tokenDecimalList[index])
+      )).then(() => {
+      res.status(200).json({
+        network: eth.network,
+        timestamp: initTime,
+        latency: latency(initTime, Date.now()),
+        balances: balances
+      })
+    })
+  } catch (err) {
+    let reason
+    err.reason ? reason = err.reason : reason = statusMessages.operation_error
+    res.status(500).json({
+      error: reason,
+      message: err
+    })
+  }
+})
+
+router.post('/allowances-2', async (req, res) => {
+  /*
+      POST: /allowances
+      x-www-form-urlencoded: {
+        privateKey:{{privateKey}}
+        tokenAddressList:{{tokenAddressList}}
+        tokenDecimalList:{{tokenDecimalList}}
+        connector:{{connector_name}}
+      }
+  */
+  const initTime = Date.now()
+  const paramData = getParamData(req.body)
+  const privateKey = paramData.privateKey
+  const spender = spenders[paramData.connector]
+  let wallet
+  try {
+    wallet = new ethers.Wallet(privateKey, eth.provider)
+  } catch (err) {
+    let reason
+    err.reason ? reason = err.reason : reason = 'Error getting wallet'
+    res.status(500).json({
+      error: reason,
+      message: err
+    })
+    return
+  }
+  let tokenAddressList
+  if (paramData.tokenAddressList) {
+    tokenAddressList = paramData.tokenAddressList.split(',')
+  }
+  let tokenDecimalList
+  if (paramData.tokenDecimalList) {
+    tokenDecimalList = paramData.tokenDecimalList.split(',')
+  }
+
+  const approvals = {}
+  try {
+    Promise.all(
+      tokenAddressList.map(async (value, index) =>
+      approvals[value] = await eth.getERC20Allowance(wallet, spender, value, tokenDecimalList[index])
+      )).then(() => {
+      res.status(200).json({
+        network: eth.network,
+        timestamp: initTime,
+        latency: latency(initTime, Date.now()),
+        spender: spender,
+        approvals: approvals,
+      })
+    }
+    )
+  } catch (err) {
+    let reason
+    err.reason ? reason = err.reason : reason = statusMessages.operation_error
+    res.status(500).json({
+      error: reason,
+      message: err
+    })
+  }
+})
+
 router.post('/approve', async (req, res) => {
   /*
       POST: /approve

--- a/src/routes/terra.route.js
+++ b/src/routes/terra.route.js
@@ -2,6 +2,7 @@
 
 import express from 'express'
 import { getParamData, latency, reportConnectionError, statusMessages } from '../services/utils';
+import { logger } from '../services/logger';
 
 import Terra from '../services/terra';
 
@@ -57,6 +58,7 @@ router.post('/balances', async (req, res) => {
       balances: balances,
     })
   } catch (err) {
+    logger.error(req.originalUrl, { message: err })
     let message
     let reason
     err.reason ? reason = err.reason : reason = statusMessages.operation_error
@@ -116,6 +118,7 @@ router.post('/price', async (req, res) => {
       }
     )
   } catch (err) {
+    logger.error(req.originalUrl, { message: err })
     let message
     let reason
     err.reason ? reason = err.reason : reason = statusMessages.operation_error
@@ -178,6 +181,7 @@ router.post('/trade', async (req, res) => {
       swapResult
     )
   } catch (err) {
+    logger.error(req.originalUrl, { message: err })
     let message
     let reason
     err.reason ? reason = err.reason : reason = statusMessages.operation_error

--- a/src/routes/uniswap.route.js
+++ b/src/routes/uniswap.route.js
@@ -88,8 +88,14 @@ router.post('/sell-price', async (req, res) => {
   } catch (err) {
     debug(err)
     let reason
-    err.reason ? reason = err.reason : reason = statusMessages.operation_error
-    res.status(500).json({
+    let err_code = 500
+    if (Object.keys(err).includes('isInsufficientReservesError')) {
+      err_code = 200
+      reason = statusMessages.insufficient_reserves + ' in Sell at Uniswap'
+    } else {
+      err.reason ? reason = err.reason : reason = statusMessages.operation_error
+    }
+    res.status(err_code).json({
       error: reason,
       message: err
     })
@@ -140,8 +146,14 @@ router.post('/buy-price', async (req, res) => {
   } catch (err) {
     debug(err)
     let reason
-    err.reason ? reason = err.reason : reason = statusMessages.operation_error
-    res.status(500).json({
+    let err_code = 500
+    if (Object.keys(err).includes('isInsufficientReservesError')) {
+      err_code = 200
+      reason = statusMessages.insufficient_reserves + ' in Buy at Uniswap'
+    } else {
+      err.reason ? reason = err.reason : reason = statusMessages.operation_error
+    }
+    res.status(err_code).json({
       error: reason,
       message: err
     })

--- a/src/routes/uniswap.route.js
+++ b/src/routes/uniswap.route.js
@@ -2,6 +2,7 @@ import { ethers } from 'ethers';
 import express from 'express';
 
 import { getParamData, latency, statusMessages } from '../services/utils';
+import { logger } from '../services/logger';
 import Uniswap from '../services/uniswap';
 
 require('dotenv').config()
@@ -15,6 +16,19 @@ const swapLessThanMaxPriceError = 'Price too low'
 
 const estimateGasLimit = () => {
   return uniswap.gasLimit
+}
+
+const getErrorMessage = (err) => {
+  /*
+    [WIP] Custom error message based-on string match
+  */
+  let message = err
+  if (err.includes('failed to meet quorum')) {
+    message = 'Failed to meet quorum'
+  } else if (err.includes('Invariant failed: ADDRESSES')) {
+    message = 'Invariant failed: ADDRESSES'
+  }
+  return message
 }
 
 router.post('/', async (req, res) => {
@@ -36,11 +50,21 @@ router.post('/gas-limit', async (req, res) => {
   */
   const gasLimit = estimateGasLimit()
 
-  res.status(200).json({
-    network: uniswap.network,
-    gasLimit: gasLimit,
-    timestamp: Date.now(),
-  })
+  try {
+    res.status(200).json({
+      network: uniswap.network,
+      gasLimit: gasLimit,
+      timestamp: Date.now(),
+    })
+  } catch (err) {
+    logger.error(req.originalUrl, { message: err })
+    let reason
+    err.reason ? reason = err.reason : reason = statusMessages.operation_error
+    res.status(500).json({
+      error: reason,
+      message: err
+    })
+  }
 })
 
 router.post('/sell-price', async (req, res) => {
@@ -61,7 +85,7 @@ router.post('/sell-price', async (req, res) => {
 
   try {
     // fetch the optimal pool mix from uniswap
-    const { trade, expectedOut} = await uniswap.priceSwapIn(
+    const { trade, expectedOut } = await uniswap.priceSwapIn(
       baseTokenAddress,     // tokenIn is base asset
       quoteTokenAddress,    // tokenOut is quote asset
       amount
@@ -86,16 +110,18 @@ router.post('/sell-price', async (req, res) => {
       })
     }
   } catch (err) {
-    debug(err)
+    logger.error(req.originalUrl, { message: err })
     let reason
-    let err_code = 500
+    let errCode = 500
     if (Object.keys(err).includes('isInsufficientReservesError')) {
-      err_code = 200
+      errCode = 200
       reason = statusMessages.insufficient_reserves + ' in Sell at Uniswap'
+    } else if (Object.getOwnPropertyNames(err).includes('message')) {
+      reason = getErrorMessage(err.message)
     } else {
       err.reason ? reason = err.reason : reason = statusMessages.operation_error
     }
-    res.status(err_code).json({
+    res.status(errCode).json({
       error: reason,
       message: err
     })
@@ -144,16 +170,18 @@ router.post('/buy-price', async (req, res) => {
       })
     }
   } catch (err) {
-    debug(err)
+    logger.error(req.originalUrl, { message: err })
     let reason
-    let err_code = 500
+    let errCode = 500
     if (Object.keys(err).includes('isInsufficientReservesError')) {
-      err_code = 200
+      errCode = 200
       reason = statusMessages.insufficient_reserves + ' in Buy at Uniswap'
+    } else if (Object.getOwnPropertyNames(err).includes('message')) {
+      reason = getErrorMessage(err.message)
     } else {
       err.reason ? reason = err.reason : reason = statusMessages.operation_error
     }
-    res.status(err_code).json({
+    res.status(errCode).json({
       error: reason,
       message: err
     })
@@ -229,6 +257,7 @@ router.post('/sell', async (req, res) => {
       debug(`Swap price ${price} lower than maxPrice ${maxPrice}`)
     }
   } catch (err) {
+    logger.error(req.originalUrl, { message: err })
     let reason
     err.reason ? reason = err.reason : reason = statusMessages.operation_error
     res.status(500).json({
@@ -270,7 +299,7 @@ router.post('/buy', async (req, res) => {
 
   try {
     // fetch the optimal pool mix from uniswap
-    const { trade, expectedIn} = await uniswap.priceSwapOut(
+    const { trade, expectedIn } = await uniswap.priceSwapOut(
       quoteTokenAddress,    // tokenIn is quote asset
       baseTokenAddress,     // tokenOut is base asset
       amount,
@@ -307,6 +336,7 @@ router.post('/buy', async (req, res) => {
       debug(`Swap price ${price} exceeds maxPrice ${maxPrice}`)
     }
   } catch (err) {
+    logger.error(req.originalUrl, { message: err })
     let reason
     err.reason ? reason = err.reason : reason = statusMessages.operation_error
     res.status(500).json({

--- a/src/services/access.js
+++ b/src/services/access.js
@@ -2,6 +2,7 @@
   middleware for validating mutual authentication access
 */
 
+import { logger } from './logger';
 import { statusMessages } from './utils';
 
 const debug = require('debug')('router')
@@ -12,10 +13,10 @@ export const validateAccess = (req, res, next) => {
     debug('Access granted')
     next()
   } else if (cert.subject) {
-    console.log('Error!', statusMessages.ssl_cert_invalid)
+    logger.error(statusMessages.ssl_cert_invalid)
     res.status(403).send({ error: statusMessages.ssl_cert_invalid })
   } else {
-    console.log('Error!', statusMessages.ssl_cert_required)
+    logger.error(statusMessages.ssl_cert_required)
     res.status(401).send({ error: statusMessages.ssl_cert_required })
   }
 }

--- a/src/services/balancer.js
+++ b/src/services/balancer.js
@@ -1,3 +1,4 @@
+import { logger } from '../services/logger';
 require('dotenv').config() // DO NOT REMOVE. needed to configure REACT_APP_SUBGRAPH_URL used by @balancer-labs/sor
 const sor = require('@balancer-labs/sor')
 const BigNumber = require('bignumber.js')
@@ -35,135 +36,164 @@ export default class Balancer {
         this.multiCall = MULTI_KOVAN;
         break;
       default:
-        throw Error(`Invalid network ${network}`)
+        const err = `Invalid network ${network}`
+        logger.error(err)
+        throw Error(err)
     }
   }
 
   async priceSwapIn (tokenIn, tokenOut, tokenInAmount, maxSwaps = MAX_SWAPS) {
     // Fetch all the pools that contain the tokens provided
-    const pools = await sor.getPoolsWithTokens(tokenIn, tokenOut)
-    if (pools.pools.length === 0) {
-      console.log('No pools contain the tokens provided', this.network);
-      return {};
+    try {
+      const pools = await sor.getPoolsWithTokens(tokenIn, tokenOut)
+      if (pools.pools.length === 0) {
+        logger.info('No pools contain the tokens provided.', { message: this.network })
+        return {};
+      }
+      logger.info('Pools Retrieved.', { message: this.network })
+
+      // Get current on-chain data about the fetched pools
+      let poolData
+      if (this.network === 'mainnet') {
+        poolData = await sor.parsePoolDataOnChain(pools.pools, tokenIn, tokenOut, this.multiCall, this.provider)
+      } else {
+        // Kovan multicall throws an ENS error
+        poolData = await sor.parsePoolData(pools.pools, tokenIn, tokenOut)
+      }
+
+      // Parse the pools and pass them to smart order outer to get the swaps needed
+      const sorSwaps = sor.smartOrderRouter(
+        poolData,                             // balancers: Pool[]
+        'swapExactIn',                        // swapType: string
+        tokenInAmount,                        // targetInputAmount: BigNumber
+        new BigNumber(maxSwaps.toString()),   // maxBalancers: number
+        0                                     // costOutputToken: BigNumber
+      )
+
+      const swapsFormatted = sor.formatSwapsExactAmountIn(sorSwaps, MAX_UINT, 0)
+      const expectedOut = sor.calcTotalOutput(swapsFormatted, poolData)
+      debug(`Expected Out: ${expectedOut.toString()} (${tokenOut})`);
+
+      // Create correct swap format for new proxy
+      let swaps = [];
+      for (let i = 0; i < swapsFormatted.length; i++) {
+        let swap = {
+          pool: swapsFormatted[i].pool,
+          tokenIn: tokenIn,
+          tokenOut: tokenOut,
+          swapAmount: swapsFormatted[i].tokenInParam,
+          limitReturnAmount: swapsFormatted[i].tokenOutParam,
+          maxPrice: swapsFormatted[i].maxPrice.toString(),
+        };
+        swaps.push(swap);
+      }
+      return { swaps, expectedOut }
+    } catch (err) {
+      logger.error(err)
+      let reason
+      err.reason ? reason = err.reason : reason = 'error in swapExactOut'
+      return reason
     }
-    console.log('Pools Retrieved.', this.network);
-
-    // Get current on-chain data about the fetched pools
-    let poolData
-    if (this.network === 'mainnet') {
-      poolData = await sor.parsePoolDataOnChain(pools.pools, tokenIn, tokenOut, this.multiCall, this.provider)
-    } else {
-      // Kovan multicall throws an ENS error
-      poolData = await sor.parsePoolData(pools.pools, tokenIn, tokenOut)
-    }
-
-    // Parse the pools and pass them to smart order outer to get the swaps needed
-    const sorSwaps = sor.smartOrderRouter(
-      poolData,                             // balancers: Pool[]
-      'swapExactIn',                        // swapType: string
-      tokenInAmount,                        // targetInputAmount: BigNumber
-      new BigNumber(maxSwaps.toString()),   // maxBalancers: number
-      0                                     // costOutputToken: BigNumber
-    )
-
-    const swapsFormatted = sor.formatSwapsExactAmountIn(sorSwaps, MAX_UINT, 0)
-    const expectedOut = sor.calcTotalOutput(swapsFormatted, poolData)
-    debug(`Expected Out: ${expectedOut.toString()} (${tokenOut})`);
-
-    // Create correct swap format for new proxy
-    let swaps = [];
-    for (let i = 0; i < swapsFormatted.length; i++) {
-      let swap = {
-        pool: swapsFormatted[i].pool,
-        tokenIn: tokenIn,
-        tokenOut: tokenOut,
-        swapAmount: swapsFormatted[i].tokenInParam,
-        limitReturnAmount: swapsFormatted[i].tokenOutParam,
-        maxPrice: swapsFormatted[i].maxPrice.toString(),
-      };
-      swaps.push(swap);
-    }
-    return { swaps, expectedOut }
   }
 
   async priceSwapOut (tokenIn, tokenOut, tokenOutAmount, maxSwaps = MAX_SWAPS) {
     // Fetch all the pools that contain the tokens provided
-    const pools = await sor.getPoolsWithTokens(tokenIn, tokenOut)
-    if (pools.pools.length === 0) {
-      console.log('No pools contain the tokens provided', this.network);
-      return {};
-    }
-    console.log('Pools Retrieved.', this.network);
+    try {
+      const pools = await sor.getPoolsWithTokens(tokenIn, tokenOut)
+      if (pools.pools.length === 0) {
+        logger.info('No pools contain the tokens provided.', { message: this.network });
+        return {};
+      }
+      logger.info('Pools Retrieved.', { message: this.network })
+      // Get current on-chain data about the fetched pools
+      let poolData
+      if (this.network === 'mainnet') {
+        poolData = await sor.parsePoolDataOnChain(pools.pools, tokenIn, tokenOut, this.multiCall, this.provider)
+      } else {
+        // Kovan multicall throws an ENS error
+        poolData = await sor.parsePoolData(pools.pools, tokenIn, tokenOut)
+      }
 
-    // Get current on-chain data about the fetched pools
-    let poolData
-    if (this.network === 'mainnet') {
-      poolData = await sor.parsePoolDataOnChain(pools.pools, tokenIn, tokenOut, this.multiCall, this.provider)
-    } else {
-      // Kovan multicall throws an ENS error
-      poolData = await sor.parsePoolData(pools.pools, tokenIn, tokenOut)
-    }
+      // Parse the pools and pass them to smart order outer to get the swaps needed
+      const sorSwaps = sor.smartOrderRouter(
+        poolData,                             // balancers: Pool[]
+        'swapExactOut',                       // swapType: string
+        tokenOutAmount,                       // targetInputAmount: BigNumber
+        new BigNumber(maxSwaps.toString()),   // maxBalancers: number
+        0                                     // costOutputToken: BigNumber
+      )
+      const swapsFormatted = sor.formatSwapsExactAmountOut(sorSwaps, MAX_UINT, MAX_UINT)
+      const expectedIn = sor.calcTotalInput(swapsFormatted, poolData)
+      debug(`Expected In: ${expectedIn.toString()} (${tokenIn})`);
 
-    // Parse the pools and pass them to smart order outer to get the swaps needed
-    const sorSwaps = sor.smartOrderRouter(
-      poolData,                             // balancers: Pool[]
-      'swapExactOut',                       // swapType: string
-      tokenOutAmount,                       // targetInputAmount: BigNumber
-      new BigNumber(maxSwaps.toString()),   // maxBalancers: number
-      0                                     // costOutputToken: BigNumber
-    )
-    const swapsFormatted = sor.formatSwapsExactAmountOut(sorSwaps, MAX_UINT, MAX_UINT)
-    const expectedIn = sor.calcTotalInput(swapsFormatted, poolData)
-    debug(`Expected In: ${expectedIn.toString()} (${tokenIn})`);
-
-    // Create correct swap format for new proxy
-    let swaps = [];
-    for (let i = 0; i < swapsFormatted.length; i++) {
-      let swap = {
-        pool: swapsFormatted[i].pool,
-        tokenIn: tokenIn,
-        tokenOut: tokenOut,
-        swapAmount: swapsFormatted[i].tokenOutParam,
-        limitReturnAmount: swapsFormatted[i].tokenInParam,
-        maxPrice: swapsFormatted[i].maxPrice.toString(),
-      };
-      swaps.push(swap);
+      // Create correct swap format for new proxy
+      let swaps = [];
+      for (let i = 0; i < swapsFormatted.length; i++) {
+        let swap = {
+          pool: swapsFormatted[i].pool,
+          tokenIn: tokenIn,
+          tokenOut: tokenOut,
+          swapAmount: swapsFormatted[i].tokenOutParam,
+          limitReturnAmount: swapsFormatted[i].tokenInParam,
+          maxPrice: swapsFormatted[i].maxPrice.toString(),
+        };
+        swaps.push(swap);
+      }
+      return { swaps, expectedIn }
+    } catch (err) {
+      logger.error(err)
+      let reason
+      err.reason ? reason = err.reason : reason = 'error in swapExactOut'
+      return reason
     }
-    return { swaps, expectedIn }
   }
 
   async swapExactIn (wallet, swaps, tokenIn, tokenOut, amountIn, minAmountOut, gasPrice) {
-    debug(`Number of swaps: ${swaps.length}`);
-    const contract = new ethers.Contract(this.exchangeProxy, proxyArtifact.abi, wallet)
-    const tx = await contract.batchSwapExactIn(
-      swaps,
-      tokenIn,
-      tokenOut,
-      amountIn,
-      0,
-      {
-        gasPrice: gasPrice * 1e9,
-        gasLimit: GAS_BASE + swaps.length * GAS_PER_SWAP,
-      }
-    )
-    debug(`Tx Hash: ${tx.hash}`);
-    return tx
+    debug(`Number of swaps: ${swaps.length}`)
+    try {
+      const contract = new ethers.Contract(this.exchangeProxy, proxyArtifact.abi, wallet)
+      const tx = await contract.batchSwapExactIn(
+        swaps,
+        tokenIn,
+        tokenOut,
+        amountIn,
+        0,
+        {
+          gasPrice: gasPrice * 1e9,
+          gasLimit: GAS_BASE + swaps.length * GAS_PER_SWAP,
+        }
+      )
+      debug(`Tx Hash: ${tx.hash}`);
+      return tx
+    } catch (err) {
+      logger.error(err)
+      let reason
+      err.reason ? reason = err.reason : reason = 'error in swapExactIn'
+      return reason
+    }
   }
 
   async swapExactOut (wallet, swaps, tokenIn, tokenOut, expectedIn, gasPrice) {
-    debug(`Number of swaps: ${swaps.length}`);
-    const contract = new ethers.Contract(this.exchangeProxy, proxyArtifact.abi, wallet)
-    const tx = await contract.batchSwapExactOut(
-      swaps,
-      tokenIn,
-      tokenOut,
-      expectedIn,
-      {
-        gasPrice: gasPrice * 1e9,
-        gasLimit: GAS_BASE + swaps.length * GAS_PER_SWAP,
-      }
-    )
-    debug(`Tx Hash: ${tx.hash}`)
-    return tx
+    debug(`Number of swaps: ${swaps.length}`)
+    try {
+      const contract = new ethers.Contract(this.exchangeProxy, proxyArtifact.abi, wallet)
+      const tx = await contract.batchSwapExactOut(
+        swaps,
+        tokenIn,
+        tokenOut,
+        expectedIn,
+        {
+          gasPrice: gasPrice * 1e9,
+          gasLimit: GAS_BASE + swaps.length * GAS_PER_SWAP,
+        }
+      )
+      debug(`Tx Hash: ${tx.hash}`)
+      return tx
+    } catch (err) {
+      logger.error(err)
+      let reason
+      err.reason ? reason = err.reason : reason = 'error in swapExactOut'
+      return reason
+    }
   }
 }

--- a/src/services/eth.js
+++ b/src/services/eth.js
@@ -65,7 +65,7 @@ export default class Ethereum {
   }
 
   // approve a spender to transfer tokens from a wallet address
-  async approveERC20 (wallet, spender, tokenAddress, amount, gasPrice = this.gasPrice, gasLimit = this.approvalGasLimit) {
+  async approveERC20 (wallet, spender, tokenAddress, amount, gasPrice = this.gasPrice, gasLimit = 50000) {
     try {
       // instantiate a contract and pass in wallet, which act on behalf of that signer
       const contract = new ethers.Contract(tokenAddress, abi.ERC20Abi, wallet)

--- a/src/services/eth.js
+++ b/src/services/eth.js
@@ -1,3 +1,5 @@
+import { logger } from './logger';
+
 require('dotenv').config()
 const fs = require('fs');
 const ethers = require('ethers')
@@ -30,6 +32,7 @@ export default class Ethereum {
       const balance = await wallet.getBalance()
       return balance / 1e18.toString()
     } catch (err) {
+      logger.error(err)
       let reason
       err.reason ? reason = err.reason : reason = 'error ETH balance lookup'
       return reason
@@ -44,6 +47,7 @@ export default class Ethereum {
       const balance = await contract.balanceOf(wallet.address)
       return balance / Math.pow(10, decimals).toString()
     } catch (err) {
+      logger.error(err)
       let reason
       err.reason ? reason = err.reason : reason = 'error balance lookup'
       return reason
@@ -58,6 +62,7 @@ export default class Ethereum {
       const allowance = await contract.allowance(wallet.address, spender)
       return allowance / Math.pow(10, decimals).toString()
     } catch (err) {
+      logger.error(err)
       let reason
       err.reason ? reason = err.reason : reason = 'error allowance lookup'
       return reason
@@ -79,6 +84,7 @@ export default class Ethereum {
         }
       )
     } catch (err) {
+      logger.error(err)
       let reason
       err.reason ? reason = err.reason : reason = 'error approval'
       return reason
@@ -94,6 +100,7 @@ export default class Ethereum {
         return gasPrice
       })
     } catch (err) {
+      logger.error(err)
       let reason
       err.reason ? reason = err.reason : reason = 'error gas lookup'
       return reason
@@ -111,6 +118,7 @@ export default class Ethereum {
         }
       )
     } catch (err) {
+      logger.error(err)
       let reason
       err.reason ? reason = err.reason : reason = 'error deposit'
       return reason

--- a/src/services/eth.js
+++ b/src/services/eth.js
@@ -40,7 +40,7 @@ export default class Ethereum {
   }
 
   // get ERC-20 token balance
-  async getERC20Balance (wallet, tokenAddress, decimals = 18) {
+  async getERC20Balance (wallet, tokenAddress, decimals) {
     // instantiate a contract and pass in provider for read-only access
     const contract = new ethers.Contract(tokenAddress, abi.ERC20Abi, this.provider)
     try {
@@ -55,7 +55,7 @@ export default class Ethereum {
   }
 
   // get ERC-20 token allowance
-  async getERC20Allowance (wallet, spender, tokenAddress, decimals = 18) {
+  async getERC20Allowance (wallet, spender, tokenAddress, decimals) {
     // instantiate a contract and pass in provider for read-only access
     const contract = new ethers.Contract(tokenAddress, abi.ERC20Abi, this.provider)
     try {

--- a/src/services/eth.js
+++ b/src/services/eth.js
@@ -65,15 +65,17 @@ export default class Ethereum {
   }
 
   // approve a spender to transfer tokens from a wallet address
-  async approveERC20 (wallet, spender, tokenAddress, amount, gasPrice = this.gasPrice, gasLimit = 50000) {
+  async approveERC20 (wallet, spender, tokenAddress, amount, gasPrice = this.gasPrice, gasLimit) {
     try {
+      // fixate gas limit to prevent overwriting
+      const approvalGasLimit = 50000
       // instantiate a contract and pass in wallet, which act on behalf of that signer
       const contract = new ethers.Contract(tokenAddress, abi.ERC20Abi, wallet)
       return await contract.approve(
         spender,
         amount, {
           gasPrice: gasPrice * 1e9,
-          gasLimit: gasLimit
+          gasLimit: approvalGasLimit
         }
       )
     } catch (err) {

--- a/src/services/eth.js
+++ b/src/services/eth.js
@@ -40,7 +40,7 @@ export default class Ethereum {
   }
 
   // get ERC-20 token balance
-  async getERC20Balance (wallet, tokenAddress, decimals) {
+  async getERC20Balance (wallet, tokenAddress, decimals = 18) {
     // instantiate a contract and pass in provider for read-only access
     const contract = new ethers.Contract(tokenAddress, abi.ERC20Abi, this.provider)
     try {
@@ -55,7 +55,7 @@ export default class Ethereum {
   }
 
   // get ERC-20 token allowance
-  async getERC20Allowance (wallet, spender, tokenAddress, decimals) {
+  async getERC20Allowance (wallet, spender, tokenAddress, decimals = 18) {
     // instantiate a contract and pass in provider for read-only access
     const contract = new ethers.Contract(tokenAddress, abi.ERC20Abi, this.provider)
     try {

--- a/src/services/logger.js
+++ b/src/services/logger.js
@@ -1,0 +1,52 @@
+const appRoot = require('app-root-path')
+const winston = require('winston');
+
+const logFormat = winston.format.combine(
+  winston.format.timestamp(),
+  winston.format.align(),
+  winston.format.printf(
+    info => {
+      const local = new Date()
+      const timestamp = local.toLocaleString()
+      return `${timestamp} | ${info.level} | ${info.message}`
+    }
+  ),
+)
+
+const config = {
+  file: {
+    level: 'info',
+    filename: `${appRoot}/logs/app.log`,
+    handleExceptions: false,
+    // maxsize: 5242880, // 5MB
+    // maxFiles: 30,
+  },
+  error: {
+    level: 'error',
+    filename: `${appRoot}/logs/error.log`,
+    handleExceptions: true,
+  },
+  rejection: {
+    level: 'error',
+    filename: `${appRoot}/logs/rejection.log`,
+  },
+  debug: {
+    level: 'debug',
+    filename: `${appRoot}/logs/debug.log`,
+    handleExceptions: true,
+  },
+}
+
+const allLogsFileTransport = new winston.transports.File(config.file)
+const errorLogsFileTransport = new winston.transports.File(config.error)
+const debugTransport = new winston.transports.Console(config.debug)
+const rejectionTransport = new winston.transports.File(config.rejection)
+
+const options = {
+  format: logFormat,
+  transports: [allLogsFileTransport, errorLogsFileTransport, debugTransport],
+  rejectionHandlers: [rejectionTransport],
+  exitOnError: false,
+}
+
+export const logger = winston.createLogger(options)

--- a/src/services/terra.js
+++ b/src/services/terra.js
@@ -1,3 +1,4 @@
+import { logger } from './logger';
 import { LCDClient, Coin, MsgSwap, StdTx, StdFee, Dec, MnemonicKey, isTxError, Coins  } from '@terra-money/terra.js'
 import BigNumber from 'bignumber.js'
 import { getHummingbotMemo } from './utils';
@@ -39,6 +40,7 @@ export default class Terra {
       this.lcd.config.gasAdjustment = GAS_ADJUSTMENT
       this.lcd.config.gasPrices = GAS_PRICE
     } catch (err) {
+      logger.error(err)
       throw Error(`Connection failed: ${this.network}`)
     }
   }
@@ -54,8 +56,8 @@ export default class Terra {
       lcd.config.gasPrices = GAS_PRICE
       return lcd
     } catch (err) {
+      logger.error(err)
       let reason
-      console.log(reason)
       err.reason ? reason = err.reason : reason = 'error Terra LCD connect'
       return reason
     }
@@ -72,8 +74,8 @@ export default class Terra {
       })
       return denom
     } catch (err) {
+      logger.error(err)
       let reason
-      console.log(reason)
       err.reason ? reason = err.reason : reason = 'error Terra Denom lookup'
       return reason
     }
@@ -85,8 +87,8 @@ export default class Terra {
       const symbol = TERRA_TOKENS[denom].symbol
       return symbol
     } catch (err) {
+      logger.error(err)
       let reason
-      console.log(reason)
       err.reason ? reason = err.reason : reason = 'error Terra Denom lookup'
       return reason
     }
@@ -105,8 +107,8 @@ export default class Terra {
       const fee = await this.lcd.tx.estimateFee(tx)
       return fee
     } catch (err) {
+      logger.error(err)
       let reason
-      console.log(reason)
       err.reason ? reason = err.reason : reason = 'error Terra estimate fee lookup'
       return reason
     }
@@ -117,8 +119,8 @@ export default class Terra {
       const exchangeRates = await this.lcd.oracle.exchangeRates()
       return exchangeRates.get(denom)
     } catch (err) {
+      logger.error(err)
       let reason
-      console.log(reason)
       err.reason ? reason = err.reason : reason = 'error Terra exchange rate lookup'
       return reason
     }
@@ -137,8 +139,8 @@ export default class Terra {
 
       return feeList
     } catch (err) {
+      logger.error(err)
       let reason
-      console.log(reason)
       err.reason ? reason = err.reason : reason = 'error Terra exchange rate lookup'
       return reason
     }
@@ -201,8 +203,8 @@ export default class Terra {
       debug('swaps', swaps)
       return swaps
     } catch (err) {
+      logger.error(err)
       let reason
-      console.log(reason)
       err.reason ? reason = err.reason : reason = 'error swap rate lookup'
       return reason
     }
@@ -222,6 +224,7 @@ export default class Terra {
       try {
         wallet = lcd.wallet(mk);
       } catch (err) {
+        logger.error(err)
         throw Error('Wallet access error')
       }
 
@@ -306,8 +309,8 @@ export default class Terra {
       })
       return tokenSwap
     } catch (err) {
+      logger.error(err)
       let reason
-      console.log(err)
       err.reason ? reason = err.reason : reason = swapResult
       return { txSuccess: false, message: reason }
     }

--- a/src/services/uniswap.js
+++ b/src/services/uniswap.js
@@ -1,3 +1,5 @@
+import { logger } from './logger';
+
 const uni = require('@uniswap/sdk')
 const ethers = require('ethers')
 const proxyArtifact = require('../static/uniswap_v2_router_abi.json')
@@ -25,7 +27,9 @@ export default class Uniswap {
         this.chainID = uni.ChainId.KOVAN;
         break;
       default:
-        throw Error(`Invalid network ${network}`)
+        const err = `Invalid network ${network}`
+        logger.error(err)
+        throw Error(err)
     }
   }
 
@@ -39,7 +43,8 @@ export default class Uniswap {
         route = new uni.Route([pair], tIn, tOut)
       }
       catch(err) {
-        console.log('Trying alternative/indirect route.')
+        logger.error(err)
+        logger.info('Trying alternative/indirect route.')
         pairOne = await uni.Fetcher.fetchPairData(tIn, uni.WETH[this.chainID])
         pairTwo = await uni.Fetcher.fetchPairData(tOut, uni.WETH[this.chainID])
         route = new uni.Route([pairOne, pairTwo], tIn, tOut)

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -10,6 +10,7 @@ export const statusMessages = {
   no_pool_available: 'No Pool Available',
   invalid_token_symbol: 'Invalid Token Symbol',
   insufficient_reserves: 'Insufficient Liquidity Reserves',
+  page_not_found: 'Page not found. Invalid path',
 }
 
 export const latency = (startTime, endTime) => parseFloat((endTime - startTime) / 1000)

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -9,6 +9,7 @@ export const statusMessages = {
   operation_error: 'Operation Error',
   no_pool_available: 'No Pool Available',
   invalid_token_symbol: 'Invalid Token Symbol',
+  insufficient_reserves: 'Insufficient Liquidity Reserves',
 }
 
 export const latency = (startTime, endTime) => parseFloat((endTime - startTime) / 1000)
@@ -71,8 +72,11 @@ export const strToDecimal = (str) => parseInt(str) / 100;
 
 export const getHummingbotMemo = () => {
   const prefix = 'hbot'
-  const clientId = process.env.HUMMINGBOT_CLIENT_ID || ''
-  return [prefix, clientId].join('-')
+  const clientId = process.env.HUMMINGBOT_INSTANCE_ID
+  if ((typeof clientId !== 'undefined' && clientId != null) && clientId !== '') {
+    return [prefix, clientId].join('-')
+  }
+  return prefix
 }
 
 export const loadConfig = () => {

--- a/test/postman/Gateway-Ethereum-Base.postman_collection.json
+++ b/test/postman/Gateway-Ethereum-Base.postman_collection.json
@@ -1,0 +1,1264 @@
+{
+	"info": {
+		"_postman_id": "e39af94e-6095-479e-8ba0-66930b12e364",
+		"name": "Gateway-Ethereum-Base",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "ethereum",
+			"item": [
+				{
+					"name": "eth/balances",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "tokenAddressList",
+									"value": "{ \"{{WETH}}\": 18,  \"{{DAI}}\": 18}",
+									"type": "text"
+								},
+								{
+									"key": "connector",
+									"value": "balancer",
+									"type": "text"
+								},
+								{
+									"key": "privateKey",
+									"value": "{{privateKey}}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/eth/balances",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"eth",
+								"balances"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "eth/allowances",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "tokenAddressList",
+									"value": "{ \"{{BAT}}\": 18, \"{{DAI}}\": 18 }",
+									"type": "text"
+								},
+								{
+									"key": "connector",
+									"value": "balancer",
+									"type": "text"
+								},
+								{
+									"key": "privateKey",
+									"value": "{{privateKey}}",
+									"type": "text"
+								}
+							],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/eth/allowances",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"eth",
+								"allowances"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "eth/approve",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "tokenAddress",
+									"value": "{{WETH}}",
+									"type": "text"
+								},
+								{
+									"key": "privateKey",
+									"value": "{{privateKey}}",
+									"type": "text"
+								},
+								{
+									"key": "gasPrice",
+									"value": "23",
+									"type": "text"
+								},
+								{
+									"key": "decimals",
+									"value": "18",
+									"type": "text"
+								},
+								{
+									"key": "connector",
+									"value": "balancer",
+									"type": "text"
+								},
+								{
+									"key": "amount",
+									"value": "999999",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/eth/approve",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"eth",
+								"approve"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "eth/get-weth",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "gasPrice",
+									"value": "31",
+									"type": "text"
+								},
+								{
+									"key": "amount",
+									"value": "0.03",
+									"type": "text"
+								},
+								{
+									"key": "privateKey",
+									"value": "{{privateKey}}",
+									"type": "text"
+								},
+								{
+									"key": "tokenAddress",
+									"value": "{{WETH}}",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/eth/get-weth",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"eth",
+								"get-weth"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "eth/get-receipt",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "txHash",
+									"value": "{{txHash}}",
+									"type": "text"
+								}
+							],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/eth/get-receipt",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"eth",
+								"get-receipt"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "balancer",
+			"item": [
+				{
+					"name": "balancer",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/balancer",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"balancer"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "balancer/gas-limit",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "maxSwaps",
+									"value": "3",
+									"type": "text"
+								}
+							],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/balancer/gas-limit",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"balancer",
+								"gas-limit"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "balancer/buy-price/",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "base",
+									"value": "{{BAT}}",
+									"type": "text"
+								},
+								{
+									"key": "quote",
+									"value": "{{DAI}}",
+									"type": "text"
+								},
+								{
+									"key": "amount",
+									"value": "10",
+									"type": "text"
+								},
+								{
+									"key": "maxSwaps",
+									"value": "4",
+									"type": "text"
+								},
+								{
+									"key": "base_decimals",
+									"value": "18",
+									"type": "text"
+								},
+								{
+									"key": "quote_decimals",
+									"value": "18",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/balancer/buy-price",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"balancer",
+								"buy-price"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "{network}/quote",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/{{network}}/quote/trading_pair/{{celo-cusd}}/amount/1",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"{{network}}",
+										"quote",
+										"trading_pair",
+										"{{celo-cusd}}",
+										"amount",
+										"1"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Security-Policy",
+									"value": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+								},
+								{
+									"key": "X-DNS-Prefetch-Control",
+									"value": "off"
+								},
+								{
+									"key": "Expect-CT",
+									"value": "max-age=0"
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "SAMEORIGIN"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=15552000; includeSubDomains"
+								},
+								{
+									"key": "X-Download-Options",
+									"value": "noopen"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "X-Permitted-Cross-Domain-Policies",
+									"value": "none"
+								},
+								{
+									"key": "Referrer-Policy",
+									"value": "no-referrer"
+								},
+								{
+									"key": "X-XSS-Protection",
+									"value": "0"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=utf-8"
+								},
+								{
+									"key": "Content-Length",
+									"value": "97"
+								},
+								{
+									"key": "ETag",
+									"value": "W/\"61-Wemp9YmP9g/CsUFMa7Y5zK6SoLQ\""
+								},
+								{
+									"key": "Date",
+									"value": "Wed, 23 Sep 2020 18:07:26 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"timestamp\": 1600884444051,\n    \"latency\": 2.542,\n    \"trading_pair\": \"CELO-CUSD\",\n    \"price\": 2.5435604641582747\n}"
+						}
+					]
+				},
+				{
+					"name": "balancer/sell-price/",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "base",
+									"value": "{{BAT}}",
+									"type": "text"
+								},
+								{
+									"key": "quote",
+									"value": "{{DAI}}",
+									"type": "text"
+								},
+								{
+									"key": "amount",
+									"value": "10",
+									"type": "text"
+								},
+								{
+									"key": "maxSwaps",
+									"value": "4",
+									"type": "text"
+								},
+								{
+									"key": "base_decimals",
+									"value": "18",
+									"type": "text"
+								},
+								{
+									"key": "quote_decimals",
+									"value": "18",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/balancer/sell-price",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"balancer",
+								"sell-price"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "{network}/quote",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/{{network}}/quote/trading_pair/{{celo-cusd}}/amount/1",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"{{network}}",
+										"quote",
+										"trading_pair",
+										"{{celo-cusd}}",
+										"amount",
+										"1"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Security-Policy",
+									"value": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+								},
+								{
+									"key": "X-DNS-Prefetch-Control",
+									"value": "off"
+								},
+								{
+									"key": "Expect-CT",
+									"value": "max-age=0"
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "SAMEORIGIN"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=15552000; includeSubDomains"
+								},
+								{
+									"key": "X-Download-Options",
+									"value": "noopen"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "X-Permitted-Cross-Domain-Policies",
+									"value": "none"
+								},
+								{
+									"key": "Referrer-Policy",
+									"value": "no-referrer"
+								},
+								{
+									"key": "X-XSS-Protection",
+									"value": "0"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=utf-8"
+								},
+								{
+									"key": "Content-Length",
+									"value": "97"
+								},
+								{
+									"key": "ETag",
+									"value": "W/\"61-Wemp9YmP9g/CsUFMa7Y5zK6SoLQ\""
+								},
+								{
+									"key": "Date",
+									"value": "Wed, 23 Sep 2020 18:07:26 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"timestamp\": 1600884444051,\n    \"latency\": 2.542,\n    \"trading_pair\": \"CELO-CUSD\",\n    \"price\": 2.5435604641582747\n}"
+						}
+					]
+				},
+				{
+					"name": "balancer/buy",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "base",
+									"value": "{{BAT}}",
+									"type": "text"
+								},
+								{
+									"key": "quote",
+									"value": "{{DAI}}",
+									"type": "text"
+								},
+								{
+									"key": "amount",
+									"value": "1",
+									"type": "text"
+								},
+								{
+									"key": "maxSwaps",
+									"value": "4",
+									"type": "text"
+								},
+								{
+									"key": "maxPrice",
+									"value": "0.19767217120251",
+									"type": "text"
+								},
+								{
+									"key": "gasPrice",
+									"value": "37",
+									"type": "text"
+								},
+								{
+									"key": "privateKey",
+									"value": "{{privateKey}}",
+									"type": "text"
+								},
+								{
+									"key": "base_decimals",
+									"value": "18",
+									"type": "text"
+								},
+								{
+									"key": "quote_decimals",
+									"value": "18",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/balancer/buy",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"balancer",
+								"buy"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "{network}/quote",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/{{network}}/quote/trading_pair/{{celo-cusd}}/amount/1",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"{{network}}",
+										"quote",
+										"trading_pair",
+										"{{celo-cusd}}",
+										"amount",
+										"1"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Security-Policy",
+									"value": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+								},
+								{
+									"key": "X-DNS-Prefetch-Control",
+									"value": "off"
+								},
+								{
+									"key": "Expect-CT",
+									"value": "max-age=0"
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "SAMEORIGIN"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=15552000; includeSubDomains"
+								},
+								{
+									"key": "X-Download-Options",
+									"value": "noopen"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "X-Permitted-Cross-Domain-Policies",
+									"value": "none"
+								},
+								{
+									"key": "Referrer-Policy",
+									"value": "no-referrer"
+								},
+								{
+									"key": "X-XSS-Protection",
+									"value": "0"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=utf-8"
+								},
+								{
+									"key": "Content-Length",
+									"value": "97"
+								},
+								{
+									"key": "ETag",
+									"value": "W/\"61-Wemp9YmP9g/CsUFMa7Y5zK6SoLQ\""
+								},
+								{
+									"key": "Date",
+									"value": "Wed, 23 Sep 2020 18:07:26 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"timestamp\": 1600884444051,\n    \"latency\": 2.542,\n    \"trading_pair\": \"CELO-CUSD\",\n    \"price\": 2.5435604641582747\n}"
+						}
+					]
+				},
+				{
+					"name": "balancer/sell",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "base",
+									"value": "{{BAT}}",
+									"type": "text"
+								},
+								{
+									"key": "quote",
+									"value": "{{DAI}}",
+									"type": "text"
+								},
+								{
+									"key": "amount",
+									"value": "0.1",
+									"type": "text"
+								},
+								{
+									"key": "maxSwaps",
+									"value": "4",
+									"type": "text"
+								},
+								{
+									"key": "maxPrice",
+									"value": "0.2685681573104575",
+									"type": "text"
+								},
+								{
+									"key": "gasPrice",
+									"value": "37",
+									"type": "text"
+								},
+								{
+									"key": "privateKey",
+									"value": "{{privateKey}}",
+									"type": "text"
+								},
+								{
+									"key": "base_decimals",
+									"value": "18",
+									"type": "text"
+								},
+								{
+									"key": "quote_decimals",
+									"value": "18",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/balancer/sell",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"balancer",
+								"sell"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "{network}/quote",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/{{network}}/quote/trading_pair/{{celo-cusd}}/amount/1",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"{{network}}",
+										"quote",
+										"trading_pair",
+										"{{celo-cusd}}",
+										"amount",
+										"1"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Security-Policy",
+									"value": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+								},
+								{
+									"key": "X-DNS-Prefetch-Control",
+									"value": "off"
+								},
+								{
+									"key": "Expect-CT",
+									"value": "max-age=0"
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "SAMEORIGIN"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=15552000; includeSubDomains"
+								},
+								{
+									"key": "X-Download-Options",
+									"value": "noopen"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "X-Permitted-Cross-Domain-Policies",
+									"value": "none"
+								},
+								{
+									"key": "Referrer-Policy",
+									"value": "no-referrer"
+								},
+								{
+									"key": "X-XSS-Protection",
+									"value": "0"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=utf-8"
+								},
+								{
+									"key": "Content-Length",
+									"value": "97"
+								},
+								{
+									"key": "ETag",
+									"value": "W/\"61-Wemp9YmP9g/CsUFMa7Y5zK6SoLQ\""
+								},
+								{
+									"key": "Date",
+									"value": "Wed, 23 Sep 2020 18:07:26 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"timestamp\": 1600884444051,\n    \"latency\": 2.542,\n    \"trading_pair\": \"CELO-CUSD\",\n    \"price\": 2.5435604641582747\n}"
+						}
+					]
+				}
+			],
+			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "uniswap",
+			"item": [
+				{
+					"name": "uniswap",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/uniswap",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"uniswap"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "uniswap/gas-limit",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [],
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/uniswap/gas-limit",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"uniswap",
+								"gas-limit"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "uniswap/buy-price/",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "base",
+									"value": "{{BAT}}",
+									"type": "text"
+								},
+								{
+									"key": "quote",
+									"value": "{{DAI}}",
+									"type": "text"
+								},
+								{
+									"key": "amount",
+									"value": "10",
+									"type": "text"
+								},
+								{
+									"key": "base_decimals",
+									"value": "18",
+									"type": "text"
+								},
+								{
+									"key": "quote_decimals",
+									"value": "18",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/uniswap/buy-price",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"uniswap",
+								"buy-price"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "{network}/quote",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/{{network}}/quote/trading_pair/{{celo-cusd}}/amount/1",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"{{network}}",
+										"quote",
+										"trading_pair",
+										"{{celo-cusd}}",
+										"amount",
+										"1"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Security-Policy",
+									"value": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+								},
+								{
+									"key": "X-DNS-Prefetch-Control",
+									"value": "off"
+								},
+								{
+									"key": "Expect-CT",
+									"value": "max-age=0"
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "SAMEORIGIN"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=15552000; includeSubDomains"
+								},
+								{
+									"key": "X-Download-Options",
+									"value": "noopen"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "X-Permitted-Cross-Domain-Policies",
+									"value": "none"
+								},
+								{
+									"key": "Referrer-Policy",
+									"value": "no-referrer"
+								},
+								{
+									"key": "X-XSS-Protection",
+									"value": "0"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=utf-8"
+								},
+								{
+									"key": "Content-Length",
+									"value": "97"
+								},
+								{
+									"key": "ETag",
+									"value": "W/\"61-Wemp9YmP9g/CsUFMa7Y5zK6SoLQ\""
+								},
+								{
+									"key": "Date",
+									"value": "Wed, 23 Sep 2020 18:07:26 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"timestamp\": 1600884444051,\n    \"latency\": 2.542,\n    \"trading_pair\": \"CELO-CUSD\",\n    \"price\": 2.5435604641582747\n}"
+						}
+					]
+				},
+				{
+					"name": "uniswap/sell-price/",
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "urlencoded",
+							"urlencoded": [
+								{
+									"key": "base",
+									"value": "{{BAT}}",
+									"type": "text"
+								},
+								{
+									"key": "quote",
+									"value": "{{DAI}}",
+									"type": "text"
+								},
+								{
+									"key": "amount",
+									"value": "10",
+									"type": "text"
+								},
+								{
+									"key": "base_decimals",
+									"value": "18",
+									"type": "text"
+								},
+								{
+									"key": "quote_decimals",
+									"value": "18",
+									"type": "text"
+								}
+							]
+						},
+						"url": {
+							"raw": "https://localhost:{{port}}/uniswap/sell-price",
+							"protocol": "https",
+							"host": [
+								"localhost"
+							],
+							"port": "{{port}}",
+							"path": [
+								"uniswap",
+								"sell-price"
+							]
+						}
+					},
+					"response": [
+						{
+							"name": "{network}/quote",
+							"originalRequest": {
+								"method": "GET",
+								"header": [],
+								"url": {
+									"raw": "http://localhost:5000/{{network}}/quote/trading_pair/{{celo-cusd}}/amount/1",
+									"protocol": "http",
+									"host": [
+										"localhost"
+									],
+									"port": "5000",
+									"path": [
+										"{{network}}",
+										"quote",
+										"trading_pair",
+										"{{celo-cusd}}",
+										"amount",
+										"1"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Security-Policy",
+									"value": "default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests"
+								},
+								{
+									"key": "X-DNS-Prefetch-Control",
+									"value": "off"
+								},
+								{
+									"key": "Expect-CT",
+									"value": "max-age=0"
+								},
+								{
+									"key": "X-Frame-Options",
+									"value": "SAMEORIGIN"
+								},
+								{
+									"key": "Strict-Transport-Security",
+									"value": "max-age=15552000; includeSubDomains"
+								},
+								{
+									"key": "X-Download-Options",
+									"value": "noopen"
+								},
+								{
+									"key": "X-Content-Type-Options",
+									"value": "nosniff"
+								},
+								{
+									"key": "X-Permitted-Cross-Domain-Policies",
+									"value": "none"
+								},
+								{
+									"key": "Referrer-Policy",
+									"value": "no-referrer"
+								},
+								{
+									"key": "X-XSS-Protection",
+									"value": "0"
+								},
+								{
+									"key": "Content-Type",
+									"value": "application/json; charset=utf-8"
+								},
+								{
+									"key": "Content-Length",
+									"value": "97"
+								},
+								{
+									"key": "ETag",
+									"value": "W/\"61-Wemp9YmP9g/CsUFMa7Y5zK6SoLQ\""
+								},
+								{
+									"key": "Date",
+									"value": "Wed, 23 Sep 2020 18:07:26 GMT"
+								},
+								{
+									"key": "Connection",
+									"value": "keep-alive"
+								}
+							],
+							"cookie": [],
+							"body": "{\n    \"timestamp\": 1600884444051,\n    \"latency\": 2.542,\n    \"trading_pair\": \"CELO-CUSD\",\n    \"price\": 2.5435604641582747\n}"
+						}
+					]
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"protocolProfileBehavior": {}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -861,6 +861,15 @@
     bignumber.js "^9.0.0"
     isomorphic-fetch "^2.2.1"
 
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
+  integrity sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
+
 "@eslint/eslintrc@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.1.3.tgz#7d1a2b2358552cc04834c0979bd4275362e37085"
@@ -1357,6 +1366,11 @@ anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+app-root-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/app-root-path/-/app-root-path-3.0.0.tgz#210b6f43873227e18a4b810a032283311555d5ad"
+  integrity sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw==
+
 argle@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/argle/-/argle-1.1.1.tgz#0cfe3bc032c36b2f48ba42b9c17f89f70607e994"
@@ -1408,6 +1422,11 @@ astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
   integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
+
+async@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
+  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
 
 available-typed-arrays@^1.0.0, available-typed-arrays@^1.0.2:
   version "1.0.2"
@@ -1685,7 +1704,7 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -1704,10 +1723,39 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.5.2:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.4.tgz#dd51cd25cfee953d138fe4002372cc3d0e504cb6"
+  integrity sha512-57yF5yt8Xa3czSEW1jfQDE79Idk0+AkN/4KWad6tbdxUmAs3MvjxlWSWD4deYytcRfoZ9nhKyFl1kj5tBvidbw==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@3.0.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
+  integrity sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.2"
+
+colors@^1.2.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
+colorspace@1.1.x:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.2.tgz#e0128950d082b86a2168580796a0aa5d6c68d8c5"
+  integrity sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==
+  dependencies:
+    color "3.0.x"
+    text-hex "1.0.x"
 
 commander@^4.0.1:
   version "4.1.1"
@@ -1964,6 +2012,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -2340,6 +2393,16 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-safe-stringify@^2.0.4:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
+fecha@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.0.tgz#3ffb6395453e3f3efff850404f0a59b6747f5f41"
+  integrity sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==
+
 file-entry-cache@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
@@ -2408,6 +2471,11 @@ flatted@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
+
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 follow-redirects@^1.10.0:
   version "1.13.0"
@@ -2745,6 +2813,11 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
@@ -2840,6 +2913,11 @@ is-stream@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
 
 is-string@^1.0.5:
   version "1.0.5"
@@ -2960,6 +3038,11 @@ keyv@^3.0.0:
   dependencies:
     json-buffer "3.0.0"
 
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
 latest-version@^5.0.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"
@@ -3027,6 +3110,17 @@ lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+logform@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.2.0.tgz#40f036d19161fc76b68ab50fdc7fe495544492f2"
+  integrity sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==
+  dependencies:
+    colors "^1.2.1"
+    fast-safe-stringify "^2.0.4"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    triple-beam "^1.3.0"
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -3295,6 +3389,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
+
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -3593,7 +3694,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.1.4:
+readable-stream@^2.1.4, readable-stream@^2.3.7:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -3606,7 +3707,7 @@ readable-stream@^2.1.4:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^3.6.0:
+readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -3838,6 +3939,13 @@ signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
+
 slice-ansi@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
@@ -3895,6 +4003,11 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
 
 "statuses@>= 1.5.0 < 2", statuses@~1.5.0:
   version "1.5.0"
@@ -4007,6 +4120,11 @@ term-size@^2.1.0:
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.0.tgz#1f16adedfe9bdc18800e1776821734086fcc6753"
   integrity sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -4066,6 +4184,11 @@ touch@^3.1.0:
   integrity sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==
   dependencies:
     nopt "~1.0.10"
+
+triple-beam@^1.2.0, triple-beam@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
+  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
 tsconfig-paths@^3.9.0:
   version "3.9.0"
@@ -4268,6 +4391,29 @@ wif@^2.0.6:
   integrity sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=
   dependencies:
     bs58check "<3.0.0"
+
+winston-transport@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.4.0.tgz#17af518daa690d5b2ecccaa7acf7b20ca7925e59"
+  integrity sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==
+  dependencies:
+    readable-stream "^2.3.7"
+    triple-beam "^1.2.0"
+
+winston@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.3.3.tgz#ae6172042cafb29786afa3d09c8ff833ab7c9170"
+  integrity sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==
+  dependencies:
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.1.0"
+    is-stream "^2.0.0"
+    logform "^2.2.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
 
 word-wrap@^1.2.3:
   version "1.2.3"


### PR DESCRIPTION
This PR added new routes for `allowances` and `balances` that separates the input params into 2 arrays for addresses and decimals, rather than a key-value dict. This makes it much easier to to test the API with Postman.

Since incorporating this change would require a similar change in the client and we should discuss this change internally, I'm marking this as Draft.