### PR TITLE
(fix) Auto increase the nonce when Strategy connects to 2 DEFI projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "debug": "^4.2.0",
     "dotenv": "^8.2.0",
     "ethers": "^5.0.14",
+    "@ethersproject/experimental": "^5.0.10",
     "express": "^4.17.1",
     "express-ipfilter": "^1.1.2",
     "helmet": "^4.1.1",

--- a/src/services/balancer.js
+++ b/src/services/balancer.js
@@ -1,5 +1,6 @@
 import { logger } from '../services/logger';
 const debug = require('debug')('router')
+import { getNonceManager } from './utils';
 require('dotenv').config() // DO NOT REMOVE. needed to configure REACT_APP_SUBGRAPH_URL used by @balancer-labs/sor
 const sor = require('@balancer-labs/sor')
 const BigNumber = require('bignumber.js')
@@ -158,7 +159,8 @@ export default class Balancer {
   async swapExactIn (wallet, swaps, tokenIn, tokenOut, amountIn, minAmountOut, gasPrice) {
     debug(`Number of swaps: ${swaps.length}`)
     try {
-      const contract = new ethers.Contract(this.exchangeProxy, proxyArtifact.abi, wallet)
+      const signer = await getNonceManager(wallet)
+      const contract = new ethers.Contract(this.exchangeProxy, proxyArtifact.abi, signer)
       const tx = await contract.batchSwapExactIn(
         swaps,
         tokenIn,
@@ -183,7 +185,8 @@ export default class Balancer {
   async swapExactOut (wallet, swaps, tokenIn, tokenOut, expectedIn, gasPrice) {
     debug(`Number of swaps: ${swaps.length}`)
     try {
-      const contract = new ethers.Contract(this.exchangeProxy, proxyArtifact.abi, wallet)
+      const signer = await getNonceManager(wallet)
+      const contract = new ethers.Contract(this.exchangeProxy, proxyArtifact.abi, signer)
       const tx = await contract.batchSwapExactOut(
         swaps,
         tokenIn,

--- a/src/services/eth.js
+++ b/src/services/eth.js
@@ -1,5 +1,6 @@
 import { logger } from './logger';
 import axios from 'axios'
+import { getNonceManager } from './utils';
 
 const debug = require('debug')('router')
 require('dotenv').config()
@@ -74,7 +75,8 @@ export default class Ethereum {
       // fixate gas limit to prevent overwriting
       const approvalGasLimit = APPROVAL_GAS_LIMIT
       // instantiate a contract and pass in wallet, which act on behalf of that signer
-      const contract = new ethers.Contract(tokenAddress, abi.ERC20Abi, wallet)
+      const signer = await getNonceManager(wallet)
+      const contract = new ethers.Contract(tokenAddress, abi.ERC20Abi, signer)
       return await contract.approve(
         spender,
         amount, {
@@ -109,7 +111,8 @@ export default class Ethereum {
   async deposit (wallet, tokenAddress, amount, gasPrice = this.gasPrice, gasLimit = this.approvalGasLimit) {
     // deposit ETH to a contract address
     try {
-      const contract = new ethers.Contract(tokenAddress, abi.KovanWETHAbi, wallet)
+      const signer = await getNonceManager(wallet)
+      const contract = new ethers.Contract(tokenAddress, abi.KovanWETHAbi, signer)
       return await contract.deposit(
         { value: amount,
           gasPrice: gasPrice * 1e9,

--- a/src/services/perpetual_finance.js
+++ b/src/services/perpetual_finance.js
@@ -1,4 +1,5 @@
 import { logger } from './logger';
+import { getNonceManager } from './utils';
 
 const fetch = require('cross-fetch');
 
@@ -144,7 +145,8 @@ export default class PerpetualFinance {
   async approve (wallet, amount) {
     try {
       // instantiate a contract and pass in wallet
-      const layer2Usdc = new Ethers.Contract(this.xUsdcAddr, TetherTokenArtifact.abi, wallet)
+      const signer = await getNonceManager(wallet)
+      const layer2Usdc = new Ethers.Contract(this.xUsdcAddr, TetherTokenArtifact.abi, signer)
       const tx = await layer2Usdc.approve(this.ClearingHouse, Ethers.utils.parseUnits(amount, DEFAULT_DECIMALS))
       // TO-DO: We may want to supply custom gasLimit value above
       return tx.hash
@@ -162,7 +164,8 @@ export default class PerpetualFinance {
       const quoteAssetAmount = { d: Ethers.utils.parseUnits(margin, DEFAULT_DECIMALS) }
       const leverage = { d: Ethers.utils.parseUnits(levrg, DEFAULT_DECIMALS) }
       const minBaseAssetAmount = { d: Ethers.utils.parseUnits(minBaseAmount, DEFAULT_DECIMALS) }
-      const clearingHouse = new Ethers.Contract(this.ClearingHouse, ClearingHouseArtifact.abi, wallet)
+      const signer = await getNonceManager(wallet)
+      const clearingHouse = new Ethers.Contract(this.ClearingHouse, ClearingHouseArtifact.abi, signer)
       const tx = await clearingHouse.openPosition(
         this.amm[pair],
         side,
@@ -184,7 +187,8 @@ export default class PerpetualFinance {
   async closePosition(wallet, pair, minimalQuote) {
     try {
       const minimalQuoteAsset = { d: Ethers.utils.parseUnits(minimalQuote, DEFAULT_DECIMALS) }
-      const clearingHouse = new Ethers.Contract(this.ClearingHouse, ClearingHouseArtifact.abi, wallet)
+      const signer = await getNonceManager(wallet)
+      const clearingHouse = new Ethers.Contract(this.ClearingHouse, ClearingHouseArtifact.abi, signer)
       const tx = await clearingHouse.closePosition(this.amm[pair], minimalQuoteAsset, { gasLimit: this.gasLimit } )
       return tx
     } catch (err) {

--- a/src/services/uniswap.js
+++ b/src/services/uniswap.js
@@ -1,4 +1,5 @@
 import { logger } from './logger';
+import { getNonceManager } from './utils';
 
 const debug = require('debug')('router')
 const math =  require('mathjs')
@@ -177,7 +178,8 @@ export default class Uniswap {
       }
     )
 
-    const contract = new ethers.Contract(this.router, proxyArtifact.abi, wallet)
+    const signer = await getNonceManager(wallet)
+    const contract = new ethers.Contract(this.router, proxyArtifact.abi, signer)
     const tx = await contract.[result.methodName](
       ...result.args,
       {
@@ -201,7 +203,8 @@ export default class Uniswap {
       }
     )
 
-    const contract = new ethers.Contract(this.router, proxyArtifact.abi, wallet)
+    const signer = await getNonceManager(wallet)
+    const contract = new ethers.Contract(this.router, proxyArtifact.abi, signer)
     const tx = await contract.[result.methodName](
       ...result.args,
       {

--- a/src/services/utils.js
+++ b/src/services/utils.js
@@ -3,6 +3,7 @@
 */
 const lodash = require('lodash')
 const moment = require('moment')
+const { NonceManager } = require('@ethersproject/experimental')
 
 export const statusMessages = {
   ssl_cert_required: 'SSL Certificate required',
@@ -107,4 +108,19 @@ export const getLocalDate = () => {
     newDate = moment().utcOffset(gmtOffset, false).format('YYYY-MM-DD hh:mm:ss').trim()
   }
   return newDate
+}
+
+export const nonceManagerCache = {}
+
+export const getNonceManager = async (signer) => {
+  let key = await signer.getAddress()
+  if (signer.provider) {
+    key += (await signer.provider.getNetwork()).chainId
+  }
+  let nonceManager = nonceManagerCache[key]
+  if (typeof nonceManager === 'undefined') {
+    nonceManager = new NonceManager(signer)
+    nonceManagerCache[key] = nonceManager
+  }
+  return nonceManager
 }


### PR DESCRIPTION
When `hummingbot` connects to 2 DEFI projects, the current gateway will receive 2 requests. If the 2 projects are both in the same network and the same wallet address, the nonce will be the same. As a result, one of the transactions will be overwritten.

In this PR, we wrap the `Signer` with a `ethersproject`/`NonceManager`, the nonce will be automatically increased across the 2 projects. We also add a factory in `utils.js` to reuse the `NonceManager` only when the network and wallet address are both the same.

References:

1. The strategy shall execute 2 transactions at the same time: https://github.com/CoinAlpha/hummingbot/blob/v0.37.1/hummingbot/strategy/spot_perpetual_arbitrage/spot_perpetual_arbitrage.py#L303
2. We import the NonceManager: https://docs.ethers.io/v5/api/experimental/#experimental-noncemanager
